### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/calispel.asd
+++ b/calispel.asd
@@ -1,6 +1,6 @@
 ;;; -*- Mode: Lisp; Syntax: ANSI-Common-Lisp -*-
 
-(asdf:defsystem "calispel"
+(defsystem "calispel"
   :version "0.1"
   :maintainer "J.P. Larocque"
   :author "J.P. Larocque, et al. (see COPYRIGHT.txt)"
@@ -26,13 +26,16 @@ the occam programming language."
 ;;	       Package definition.
   :depends-on ("jpl-queues"
 	       "bordeaux-threads"
-	       (:version "jpl-util" "0.2")))
+	       (:version "jpl-util" "0.2"))
+  :in-order-to ((test-op (test-op "calispel/test"))))
 
-(asdf:defsystem "calispel-test"
+(defsystem "calispel/test"
   :version "0.1"
   :maintainer "Rick Venn (richard.venn@gmail.com)"
   :author "J.P. Larocque, et al. (see COPYRIGHT.txt)"
   :licence "ISC-style and other permissive (see COPYRIGHT.txt)"
   :description "Test suite for Calispel"
   :depends-on (:calispel :eager-future2)
-  :components ((:file "test")))
+  :components ((:file "test"))
+  :perform (test-op (o c)
+             (symbol-call :calispel-test :test-concurrency :verbose-p t)))

--- a/test.lisp
+++ b/test.lisp
@@ -1,5 +1,6 @@
 (defpackage #:calispel-test
-  (:use #:common-lisp #:calispel #:jpl-queues))
+  (:use #:common-lisp #:calispel #:jpl-queues)
+  (:export #:test-channel #:test-concurrency))
 
 (in-package #:calispel-test)
 
@@ -305,7 +306,8 @@ that this function takes at least ~10 seconds to run."
 			 (channel-count 8)
 			 (make-channel-fn (lambda () (make-instance 'channel)))
 			 (message-count 2000000)
-			 (reader-count 4) (writer-count 4))
+			 (reader-count 4) (writer-count 4)
+       &allow-other-keys)
   "Tests concurrency by creating CHANNEL-COUNT CHANNELs and running
 TEST-CHANNEL against each, simultaneously.
 


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
